### PR TITLE
add support for includedAssets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "archiver": "3.0.0",
     "lodash": "^4.17.15",
-    "make-dir": "1.3.0"
+    "make-dir": "1.3.0",
+    "mz": "^2.7.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -22,6 +23,7 @@
     "@types/archiver": "^2.1.2",
     "@types/lodash": "^4.14.118",
     "@types/make-dir": "^1.0.3",
+    "@types/mz": "^0.0.32",
     "@types/node": "^10.12.27",
     "@types/serverless": "^1.18.0",
     "@zeit/ncc": "^0.15.2",

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,9 @@ export interface IFileNameAndPath {
   name: string;
   absPath: string;
 }
+
+export type CompiledAsset = {
+  source: Buffer;
+  permissions: number;
+  name: string;
+};


### PR DESCRIPTION
allows 1) to override ncc's included assets and 2) include some extra asset not detected by ncc

usage:

```js
{
  enabled: true,
  includeAssets: ['rel/path/to/my/asset']
}
```